### PR TITLE
Error fixed in the rds section

### DIFF
--- a/otawslibs/aws_resource_tag_factory.py
+++ b/otawslibs/aws_resource_tag_factory.py
@@ -53,7 +53,7 @@ class getResoruceFinder:
             
             for tag in tags:
                 for db_tag in db_tags:
-                    if db_tag['Key'] == tag and db_tag['Value'] == tags[tag]:
+                    if db_tag['Key'] == tags['Key'] and db_tag['Value'] == tags['Value']:
                         tag_found = True
                         break
                     else:


### PR DESCRIPTION
Previous code :- 
if db_tag['Key'] == tag and db_tag['Value'] == tags[tag]:
In above condition value of tag and tags[tag] fetching the wrong value for the comparison

Update code :-
if db_tag['Key'] == tags['Key'] and db_tag['Value'] == tags['Value']:
Now value of tags['Key'] and tags['Value'] fetching the right value for the comparison